### PR TITLE
fix: update goreleaser version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.10.2
+          version: v2.12.7
           args: release --clean --timeout=60m --verbose --parallelism 2
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
2.12 is required for [dockers_v2](https://goreleaser.com/customization/dockers_v2/)