### PR TITLE
fix: avoid passing empty argument when S3CMD_EXTRA_FLAG is unset

### DIFF
--- a/kubernetes/bao-snapshot.sh
+++ b/kubernetes/bao-snapshot.sh
@@ -14,18 +14,18 @@ export BAO_TOKEN
 bao operator raft snapshot save /bao-snapshots/bao_"$(date +%F-%H%M)".snapshot
 
 # Upload to S3
-s3cmd put /bao-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" "${S3CMD_EXTRA_FLAG}"
+s3cmd put /bao-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" ${S3CMD_EXTRA_FLAG:+$S3CMD_EXTRA_FLAG}
 
 # Remove expired snapshots
 if [ "${S3_EXPIRE_DAYS}" ]; then
-    s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" "${S3CMD_EXTRA_FLAG}" | while read -r line; do
+    s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" ${S3CMD_EXTRA_FLAG:+$S3CMD_EXTRA_FLAG} | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
         olderThan=$(date --date @$(($(date +%s) - 86400*S3_EXPIRE_DAYS)) +%s)
         if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
             if [ "$fileName" != "" ]; then
-                s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" "${S3CMD_EXTRA_FLAG}"
+                s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" ${S3CMD_EXTRA_FLAG:+$S3CMD_EXTRA_FLAG}
             fi
         fi
     done;


### PR DESCRIPTION
This PR fixes a bug where an empty S3CMD_EXTRA_FLAG was passed as a positional argument to s3cmd, causing uploads to fail. Optional S3 flags are now added only when set, removing the need for a workaround configuration.

Adresses https://github.com/openbao/openbao-snapshot-agent/issues/16