### PR TITLE
feat: introduce oli (openDAL cli) as the storage access layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,36 @@
+# ---------------------------------------------------------------------------
+# Stage 1 – build the oli binary using Rust on musl (static linking)
+# ---------------------------------------------------------------------------
+FROM rust:alpine AS oli-builder
+
+RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconfig perl make
+
+# Install oli – the OpenDAL command-line interface used to upload snapshots
+# to any supported object-storage backend (S3, GCS, Azure Blob, …).
+RUN cargo install oli
+
+# ---------------------------------------------------------------------------
+# Stage 2 – final image
+# ---------------------------------------------------------------------------
 FROM alpine
 
 ARG BAO_VERSION=2.5.0
-
 ARG TARGETOS
 ARG TARGETARCH
 
 COPY kubernetes/bao-snapshot.sh /
 
-RUN if [[ "$TARGETARCH" == "amd64" ]]; then \
-        TARGETARCH="x86_64"; \
-    fi && \
-    wget https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/bao_${BAO_VERSION}_Linux_${TARGETARCH}.tar.gz && \
-    tar xzf bao_${BAO_VERSION}_Linux_${TARGETARCH}.tar.gz && \ 
-    mv bao /usr/local/bin && rm  bao*tar.gz  && \
-    apk add s3cmd && chmod +x bao-snapshot.sh
+RUN ARCH="${TARGETARCH}" && \
+    if [ "${ARCH}" = "amd64" ]; then ARCH="x86_64"; fi && \
+    wget https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/bao_${BAO_VERSION}_Linux_${ARCH}.tar.gz && \
+    tar xzf bao_${BAO_VERSION}_Linux_${ARCH}.tar.gz && \
+    mv bao /usr/local/bin && \
+    rm -f bao_*.tar.gz && \
+    apk add --no-cache ca-certificates && \
+    sed -i 's/\r//' /bao-snapshot.sh && \
+    chmod +x /bao-snapshot.sh
+
+# Copy the statically-linked oli binary from the builder stage
+COPY --from=oli-builder /usr/local/cargo/bin/oli /usr/local/bin/oli
 
 CMD ["/bao-snapshot.sh"]

--- a/kubernetes/bao-snapshot.sh
+++ b/kubernetes/bao-snapshot.sh
@@ -2,31 +2,96 @@
 
 set -e
 
+###############################################################################
 # Authenticate with OpenBao
+###############################################################################
 JWT=$(cat "${TOKEN_PATH:=/var/run/secrets/kubernetes.io/serviceaccount/token}")
 export JWT
 
 echo "Using OpenBao auth path: $BAO_AUTH_PATH"
-BAO_TOKEN=$(bao write -field=token  "auth/$BAO_AUTH_PATH/login" role="${BAO_ROLE}" jwt="${JWT}")
+BAO_TOKEN=$(bao write -field=token "auth/$BAO_AUTH_PATH/login" role="${BAO_ROLE}" jwt="${JWT}")
 export BAO_TOKEN
 
+###############################################################################
 # Create snapshot
-bao operator raft snapshot save /bao-snapshots/bao_"$(date +%F-%H%M)".snapshot
+###############################################################################
+SNAPSHOT_FILE="bao_$(date +%F-%H%M).snapshot"
+bao operator raft snapshot save "/bao-snapshots/${SNAPSHOT_FILE}"
 
-# Upload to S3
-s3cmd put /bao-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" ${S3CMD_EXTRA_FLAG:+$S3CMD_EXTRA_FLAG}
+###############################################################################
+# Build oli profile configuration
+# Supported OLI_STORAGE_TYPE values: s3, gcs, azblob
+###############################################################################
+OLI_PROFILE="${OLI_PROFILE:-bao}"
+OLI_CONFIG_DIR="${HOME}/.config/oli"
+mkdir -p "${OLI_CONFIG_DIR}"
 
-# Remove expired snapshots
-if [ "${S3_EXPIRE_DAYS}" ]; then
-    s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" ${S3CMD_EXTRA_FLAG:+$S3CMD_EXTRA_FLAG} | while read -r line; do
-        createDate=$(echo "$line" | awk '{print $1" "$2}')
-        createDate=$(date -d"$createDate" +%s)
-        olderThan=$(date --date @$(($(date +%s) - 86400*S3_EXPIRE_DAYS)) +%s)
-        if [ "$createDate" -lt "$olderThan" ]; then
-            fileName=$(echo "$line" | awk '{print $4}')
-            if [ "$fileName" != "" ]; then
-                s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" ${S3CMD_EXTRA_FLAG:+$S3CMD_EXTRA_FLAG}
-            fi
-        fi
-    done;
+{
+  printf '[profiles.%s]\n' "${OLI_PROFILE}"
+  printf 'type = "%s"\n'   "${OLI_STORAGE_TYPE}"
+  [ -n "${OLI_ROOT}" ] && printf 'root = "%s"\n' "${OLI_ROOT}"
+
+  case "${OLI_STORAGE_TYPE}" in
+    s3)
+      printf 'bucket = "%s"\n' "${OLI_BUCKET}"
+      printf 'region = "%s"\n' "${OLI_REGION:-us-east-1}"
+      [ -n "${OLI_ENDPOINT}"          ] && printf 'endpoint = "%s"\n'          "${OLI_ENDPOINT}"
+      [ -n "${AWS_ACCESS_KEY_ID}"     ] && printf 'access_key_id = "%s"\n'     "${AWS_ACCESS_KEY_ID}"
+      [ -n "${AWS_SECRET_ACCESS_KEY}" ] && printf 'secret_access_key = "%s"\n' "${AWS_SECRET_ACCESS_KEY}"
+      [ -n "${AWS_SESSION_TOKEN}"     ] && printf 'session_token = "%s"\n'     "${AWS_SESSION_TOKEN}"
+      ;;
+    gcs)
+      printf 'bucket = "%s"\n' "${OLI_BUCKET}"
+      [ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ] && printf 'credential_path = "%s"\n' "${GOOGLE_APPLICATION_CREDENTIALS}"
+      [ -n "${GCS_SERVICE_ACCOUNT_KEY}"        ] && printf 'credential = "%s"\n'      "${GCS_SERVICE_ACCOUNT_KEY}"
+      ;;
+    azblob)
+      printf 'container = "%s"\n' "${OLI_CONTAINER}"
+      [ -n "${AZURE_STORAGE_ENDPOINT}"     ] && printf 'endpoint = "%s"\n'     "${AZURE_STORAGE_ENDPOINT}"
+      [ -n "${AZURE_STORAGE_ACCOUNT_NAME}" ] && printf 'account_name = "%s"\n' "${AZURE_STORAGE_ACCOUNT_NAME}"
+      [ -n "${AZURE_STORAGE_ACCOUNT_KEY}"  ] && printf 'account_key = "%s"\n'  "${AZURE_STORAGE_ACCOUNT_KEY}"
+      [ -n "${AZURE_STORAGE_SAS_TOKEN}"    ] && printf 'sas_token = "%s"\n'    "${AZURE_STORAGE_SAS_TOKEN}"
+      ;;
+    *)
+      echo "ERROR: Unsupported OLI_STORAGE_TYPE '${OLI_STORAGE_TYPE}'. Supported values: s3, gcs, azblob" >&2
+      exit 1
+      ;;
+  esac
+} > "${OLI_CONFIG_DIR}/config.toml"
+
+###############################################################################
+# Upload snapshot to remote storage via oli
+###############################################################################
+echo "Uploading ${SNAPSHOT_FILE} to ${OLI_PROFILE}:/${SNAPSHOT_FILE} ..."
+oli cp "/bao-snapshots/${SNAPSHOT_FILE}" "${OLI_PROFILE}:/${SNAPSHOT_FILE}"
+echo "Snapshot uploaded successfully."
+
+# Remove local snapshot files now that they are safely stored remotely
+rm -f /bao-snapshots/*.snapshot
+
+###############################################################################
+# Remove expired remote snapshots
+# Snapshot filenames encode their creation date: bao_YYYY-MM-DD-HHMM.snapshot
+###############################################################################
+if [ -n "${OLI_EXPIRE_DAYS}" ]; then
+  echo "Removing snapshots older than ${OLI_EXPIRE_DAYS} days..."
+
+  NOW_SECS=$(date +%s)
+  EXPIRE_THRESHOLD_SECS=$((NOW_SECS - OLI_EXPIRE_DAYS * 86400))
+
+  oli ls "${OLI_PROFILE}:/" | while read -r fileName; do
+    # Only process .snapshot files
+    case "${fileName}" in *.snapshot) ;; *) continue ;; esac
+
+    # Extract the date from filename: bao_2026-02-26-1430.snapshot -> 2026-02-26
+    fileDate=$(printf '%s' "${fileName}" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
+    [ -z "${fileDate}" ] && continue
+
+    fileTs=$(date -d "${fileDate}" +%s 2>/dev/null) || continue
+
+    if [ "${fileTs}" -lt "${EXPIRE_THRESHOLD_SECS}" ]; then
+      echo "Removing expired snapshot: ${fileName}"
+      oli rm "${OLI_PROFILE}:/${fileName}"
+    fi
+  done
 fi

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   labels:
     app.kubernetes.io/name: bao-snapshot
-    app.kubernetes.io/version: v0.1.0
+    app.kubernetes.io/version: v0.3.0
   name: bao-snapshot
 spec:
   schedule: 0 * * * *
@@ -12,13 +12,13 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: bao-snapshot
-        app.kubernetes.io/version: v0.1.0
+        app.kubernetes.io/version: v0.3.0
     spec:
       template:
         metadata:
           labels:
             app.kubernetes.io/name: bao-snapshot
-            app.kubernetes.io/version: v0.1.0
+            app.kubernetes.io/version: v0.3.0
         spec:
           restartPolicy: Never
           automountServiceAccountToken: true
@@ -26,38 +26,101 @@ spec:
           containers:
           - name: bao-snapshot
             env:
-            - name: S3_HOST
-              value: s3.example.com
-            - name: S3_BUCKET
-              value: bucket
-            - name: S3_URI
-              value: s3://bucket
-              # leave empty to retain snapshot files (default)
-            - name: S3_EXPIRE_DAYS
-              value:
-              # Leave empty to use system trust store, use "--ca-certs=" to specify the path to the CA or "--no-check-certificate" to skip TLS verification
-            - name: S3CMD_EXTRA_FLAG
-              value:
-              # Leave empty to use default '/var/run/secrets/kubernetes.io/serviceaccount/token'
+            # ---- OpenBao connection ----
+            # Leave empty to use default '/var/run/secrets/kubernetes.io/serviceaccount/token'
             - name: TOKEN_PATH
               value:
+            - name: BAO_ADDR
+              value: https://bao.example.com
             - name: BAO_AUTH_PATH
               value: kubernetes
             - name: BAO_ROLE
               value: bao-raft-snapshot
-            - name: BAO_ADDR
-              value: https://bao.examaple.com
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: aws_secret_access_key
-                  name: bao-snapshot-credentials
+
+            # ---- oli storage provider (required) ----
+            # Supported values: s3  |  gcs  |  azblob
+            - name: OLI_STORAGE_TYPE
+              value: s3
+            # Optional: oli profile name used in config.toml (default: bao)
+            - name: OLI_PROFILE
+              value:
+            # Optional: root path inside the bucket / container (default: /)
+            - name: OLI_ROOT
+              value:
+            # Leave empty to retain all snapshots; set to a positive integer to
+            # automatically delete snapshots older than N days
+            - name: OLI_EXPIRE_DAYS
+              value:
+
+            # ---- AWS S3 / S3-compatible  (OLI_STORAGE_TYPE=s3) ----
+            - name: OLI_BUCKET
+              value: my-backup-bucket
+            - name: OLI_REGION
+              value: us-east-1
+            # Optional: custom endpoint for S3-compatible storage (MinIO, etc.)
+            - name: OLI_ENDPOINT
+              value:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   key: aws_access_key_id
                   name: bao-snapshot-credentials
-            image: ghcr.io/openbao/openbao-snapshot-agent:0.2.4
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: bao-snapshot-credentials
+                  optional: true
+            # Optional: STS session token
+            - name: AWS_SESSION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: aws_session_token
+                  name: bao-snapshot-credentials
+                  optional: true
+
+            # ---- Google Cloud Storage  (OLI_STORAGE_TYPE=gcs) ----
+            # OLI_BUCKET above is also used as the GCS bucket name.
+            # Option A – path to a service-account key file mounted into the pod:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value:  # e.g. /var/secrets/google/key.json
+            # Option B – base64-encoded service-account key JSON stored in a Secret:
+            - name: GCS_SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: gcs_service_account_key
+                  name: bao-snapshot-credentials
+                  optional: true
+
+            # ---- Azure Blob Storage  (OLI_STORAGE_TYPE=azblob) ----
+            # Container name (azblob equivalent of OLI_BUCKET)
+            - name: OLI_CONTAINER
+              value:
+            # Optional: full endpoint URL (default: https://<account>.blob.core.windows.net)
+            - name: AZURE_STORAGE_ENDPOINT
+              value:
+            - name: AZURE_STORAGE_ACCOUNT_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: azure_storage_account_name
+                  name: bao-snapshot-credentials
+                  optional: true
+            # Use either AZURE_STORAGE_ACCOUNT_KEY or AZURE_STORAGE_SAS_TOKEN:
+            - name: AZURE_STORAGE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: azure_storage_account_key
+                  name: bao-snapshot-credentials
+                  optional: true
+            - name: AZURE_STORAGE_SAS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: azure_storage_sas_token
+                  name: bao-snapshot-credentials
+                  optional: true
+
+            image: ghcr.io/openbao/openbao-snapshot-agent:0.3.0
             volumeMounts:
               - name: snapshot-dir
                 mountPath: /bao-snapshots


### PR DESCRIPTION
This introduces [OpenDAL](https://opendal.apache.org/) as an alternative to s3cmd. This allows a more flexible storage access layer to perform backups.

OpenDAL offers a cli tool called [oli](https://github.com/apache/opendal-oli) which I introduced as a replacement. 
Further supported storage types and their config can be found in the [here](https://docs.rs/opendal/0.50.2/opendal/services/index.html)

The following actions have been done:
- added oli build stage to docker image to make tool available
- refactor script to use oli instead of s3cmd
- allow multiple storage options
- introduces s3, gcp, azblob options