### PR TITLE
docs: match service account name in example

### DIFF
--- a/docs/k8s-configuration.md
+++ b/docs/k8s-configuration.md
@@ -105,7 +105,7 @@ kubectl create ns -n bao-snapshot
 
 Create the service account used for authentication:
 ```bash
-kubectl create sa -n bao-snapshot bao-snapshot
+kubectl apply -n bao-snapshot -f kubernetes/serviceaccount.yaml
 ```
 
 Deploy the Kubernetes cronjob:

--- a/kubernetes/serviceaccount.yaml
+++ b/kubernetes/serviceaccount.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: bao-raft-snapshot
+  name: bao-snapshot


### PR DESCRIPTION
- Match service account names in the example manifests. Only the service name in the `kubernetes/serviceaccount.yaml` file used `bao-raft-snapshot`, not `bao-snapshot`.
- Update Kubernetes docs to create a service account via an example manifest.