### PR TITLE
chore(ci): harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: "/kubernetes"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "chore(ci): "
     open-pull-requests-limit: 10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,29 +36,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Golang Setup
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
           check-latest: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
          
       - name: GPG Import
         id: gpg-import
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSWORD }}
 
       - name: Cache Setup
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ./dist/**
@@ -66,7 +66,7 @@ jobs:
 
       - name: "Docker Login: ghcr.io"
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -74,14 +74,14 @@ jobs:
       
       - name: "Docker Login: docker.io"
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: "Docker Login: quay.io"
         if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: "GoReleaser: Release"
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: v2.12.7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
   packages: write
 
 jobs:
@@ -37,12 +36,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Golang Setup
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
           check-latest: true
+          # Avoid cache poisoning in release builds.
+          cache: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -56,13 +59,6 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSWORD }}
-
-      - name: Cache Setup
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ./dist/**
-          key: ${{ github.ref }}
 
       - name: "Docker Login: ghcr.io"
         if: startsWith(github.ref, 'refs/tags/')
@@ -105,8 +101,6 @@ jobs:
           version: v2.12.7
           args: release --clean --timeout=60m --verbose --parallelism 2
         env:
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.gpg-import.outputs.fingerprint }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,11 +1,16 @@
 name: Shellcheck
 on: pull_request
+permissions:
+  contents: read
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run shellcheck
         id: shellcheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run shellcheck
         id: shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0

--- a/ansible/Readme.md
+++ b/ansible/Readme.md
@@ -1,6 +1,6 @@
 # OpenBao Raft Backup Agent - Ansible Configuration
 
-This directory contains Ansible instructions to deploy the Raft Backup Agent. The tasks of the role `bao-raft-backup-agent` are derived from the [manual configurations for Bare Metal/VMs](../docs/vm-configuration.md)).
+This directory contains Ansible instructions to deploy the Raft Backup Agent. The tasks of the role `bao-raft-backup-agent` are derived from the [manual configurations for Bare Metal/VMs](../docs/vm-configuration.md).
 
 Note that the playbook will only save the snapshot to a configured directory. If you want to automatically sync those to an S3 bucket, it will need to be configured on top.
 

--- a/docs/k8s-configuration.md
+++ b/docs/k8s-configuration.md
@@ -92,7 +92,7 @@ bao write auth/jwt/role/bao-snapshot \
 
 ## Configure the environment variables
 
-In `kubernetes/cronjob.yaml`, configure the environement variables according to your setup.
+In `kubernetes/cronjob.yaml`, configure the environment variables according to your setup.
 
 - `BAO_ADDR` - OpenBao address to access
 - `BAO_ROLE` - OpenBao role to use to create the snapshot
@@ -105,7 +105,7 @@ In `kubernetes/cronjob.yaml`, configure the environement variables according to 
 - `S3_BUCKET` - S3 bucket to point to
 - `S3_HOST` - S3 endpoint
 - `S3_EXPIRE_DAYS` - Delete files older than this threshold (expired)
-- `S3CMD_EXTRA_FLAG` - To specify additionnal [S3CMD flags](https://s3tools.org/usage)
+- `S3CMD_EXTRA_FLAG` - To specify additional [S3CMD flags](https://s3tools.org/usage)
 - `AWS_ACCESS_KEY_ID` - Access key to use to access S3
 - `AWS_SECRET_ACCESS_KEY` - Secret access key to use to access S3
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -21,7 +21,7 @@ After the snapshot is created in a temporary directory, `s3cmd` is used to sync 
 - `S3_BUCKET` - S3 bucket to point to
 - `S3_HOST` - S3 endpoint
 - `S3_EXPIRE_DAYS` - Delete files older than this threshold (expired)
-- `S3CMD_EXTRA_FLAG` - To specify additionnal [S3CMD flags](https://s3tools.org/usage)
+- `S3CMD_EXTRA_FLAG` - To specify additional [S3CMD flags](https://s3tools.org/usage)
 - `AWS_ACCESS_KEY_ID` - Access key to use to access S3
 - `AWS_SECRET_ACCESS_KEY` - Secret access key to use to access S3
 


### PR DESCRIPTION
# Description

Hardens the GitHub Actions workflows and dependency update configuration to reduce supply-chain and workflow security risks.

- Updates and pins GitHub Actions to full commit SHAs using `pinact run --update --min-age 5`
- Configures a 5-day Dependabot cooldown, consistent with other OpenBao repositories
  - _e.g._, https://github.com/openbao/openbao/blob/c6680303f712d2c67eaf757f51d07f5eb24e8969/.github/dependabot.yml
- Disables the `setup-go` cache in the release workflow
- Removes the `actions/cache` step that cached release artifacts under `./dist`
- Disables persisted checkout credentials where they are not required
- Restricts the Shellcheck workflow to `contents: read`
- Uses `ubuntu-slim` for the Shellcheck job
- Removes unused workflow permissions and Cosign environment variables

# Rationale

The action versions were updated with `pinact run --update --min-age 5`.
See: https://github.com/suzuki-shunsuke/pinact

The release workflow also no longer uses cached Go or `./dist` artifacts. Previous release workflow runs have completed in under two minutes, so the performance benefit of caching is limited. Since this workflow produces and publishes release artifacts, this change favors release integrity and reduces exposure to cache poisoning over a small potential performance improvement.

The remaining changes follow the principle of least privilege by avoiding unnecessary persisted credentials, permissions, and secrets.

These issues were mainly identified while reviewing the workflows with [`zizmor`](https://github.com/zizmorcore/zizmor).

I'm happy to narrow the scope if some of these changes would be better handled separately.