### PR TITLE
docs: fix command examples and typos

### DIFF
--- a/ansible/Readme.md
+++ b/ansible/Readme.md
@@ -20,6 +20,7 @@ Note that the **secretid is removed by default**. Set the variable `remove_secre
 ## Usage
 
 ### Role Usage / Playbook
+
 An example playbook is provided in the file [`playbook.yml`](./playbook.yml)
 
 ```bash
@@ -34,6 +35,7 @@ $ systemctl list-timers
 ```
 
 ## Limitations
+
 The Ansible role comes with the following limitations:
 
 * Does not configure a cron job, only a systemd timer/service pair

--- a/docs/k8s-configuration.md
+++ b/docs/k8s-configuration.md
@@ -6,7 +6,7 @@ Currently, the container image only supports S3 as the final storage for the sna
 
 ## Configure Authentication
 
-On Kubernetes, you can choose between using [JWT Authentication](https://openbao.org/docs/auth/jwt/oidc-providers/kubernetes/) or [Kubernetes Authentication](https://openbao.org/docs/auth/kubernetes/). The instructions below provides a straighforward approach to configure both methods to use with the Kubernetes Cronjob.
+On Kubernetes, you can choose between using [JWT Authentication](https://openbao.org/docs/auth/jwt/oidc-providers/kubernetes/) or [Kubernetes Authentication](https://openbao.org/docs/auth/kubernetes/). The instructions below provides a straightforward approach to configure both methods to use with the Kubernetes Cronjob.
 
 ### OpenBao Policy
 
@@ -71,11 +71,11 @@ MIIBIjANBgkqhkiG9...
 -----END PUBLIC KEY-----"
 ```
 
-4. Retrive the default audience claim of the Kubernetes cluster:
+4. Retrieve the default audience claim of the Kubernetes cluster:
 
 ```bash
 kubectl create token default | cut -f2 -d. | base64 --decode
-{"aud":["https://kubernetes.default.svc.cluster.local"], ...}
+# {"aud":["https://kubernetes.default.svc.cluster.local"], ...}
 ```
 
 5. Create a role:
@@ -111,10 +111,10 @@ In `kubernetes/cronjob.yaml`, configure the environment variables according to y
 
 ## Deploy Kubernetes Cronjob
 
-Create the destination namespace :
+Create the destination namespace:
 
 ```bash
-kubectl create ns -n bao-snapshot
+kubectl create ns bao-snapshot
 ```
 
 Create the service account used for authentication:

--- a/docs/vm-configuration.md
+++ b/docs/vm-configuration.md
@@ -31,8 +31,8 @@ bao write -f auth/approle/role/bao-snap-agent/secret-id -format=json | jq -r .da
 On all OpenBao servers:
 
 ```bash
-echo "<role_id>" > /etc/bao.d/snap-secretid
-echo "<secretd_id>" > /etc/bao.d/snap-roleid
+echo "<role_id>" > /etc/bao.d/snap-roleid
+echo "<secret_id>" > /etc/bao.d/snap-secretid
 chmod 0640 /etc/bao.d/snap-{roleid,secretid}
 chown bao:bao /etc/bao.d/snap-{roleid,secretid}
 ```
@@ -60,7 +60,7 @@ api_proxy {
 }
 
 listener "unix" {
-  # Expose OpenBao Agent API seperately
+  # Expose OpenBao Agent API separately
   # https://openbao.org/docs/agent-and-proxy/agent/caching/#configuration-listener
   address = "/etc/bao.d/agent.sock"
   tls_disable = true
@@ -179,7 +179,7 @@ echo "/usr/bin/s3cmd sync /opt/bao/snapshots/* s3://raft-snapshots" >> /usr/loca
 
 For an retention of 7 days (locally, not on the remote storage) you need to add the following to the `bao-snapshot` script:
 
-```
+```bash
 find /opt/bao/snapshots/* -mtime +7 -exec rm {} \;
 ```
 


### PR DESCRIPTION
# Description

Fixes typos and incorrect command examples in the documentation.

For example, `kubectl create ns -n bao-snapshot` fails as follows:

```console
kangetsu@ubuntu24:~/playground/openbao$ kubectl create ns -n bao-snapshot
error: exactly one NAME is required, got 0
See 'kubectl create namespace -h' for help and examples
kangetsu@ubuntu24:~/playground/openbao$ 
```