### PR TITLE
chore: Harden Docker image build and bump OpenBao version 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**
+
+!kubernetes/
+!kubernetes/bao-snapshot.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM alpine
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-ARG BAO_VERSION=2.5.0
-
-ARG TARGETOS
+ARG BAO_VERSION=2.6.1
 ARG TARGETARCH
 
 COPY kubernetes/bao-snapshot.sh /
@@ -10,9 +8,13 @@ COPY kubernetes/bao-snapshot.sh /
 RUN if [[ "$TARGETARCH" == "amd64" ]]; then \
         TARGETARCH="x86_64"; \
     fi && \
-    wget https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/bao_${BAO_VERSION}_Linux_${TARGETARCH}.tar.gz && \
-    tar xzf bao_${BAO_VERSION}_Linux_${TARGETARCH}.tar.gz && \ 
-    mv bao /usr/local/bin && rm  bao*tar.gz  && \
-    apk add s3cmd && chmod +x bao-snapshot.sh
+    wget "https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/openbao_${BAO_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    wget "https://github.com/openbao/openbao/releases/download/v${BAO_VERSION}/checksums.txt" && \
+    grep "openbao_${BAO_VERSION}_linux_${TARGETARCH}\.tar\.gz$" checksums.txt | sha256sum -c - && \
+    tar xzf "openbao_${BAO_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    mv bao /usr/local/bin && \
+    rm "openbao_${BAO_VERSION}_linux_${TARGETARCH}.tar.gz" checksums.txt && \
+    apk add --no-cache s3cmd && \
+    chmod +x bao-snapshot.sh
 
 CMD ["/bao-snapshot.sh"]


### PR DESCRIPTION
# Description

Hardens the snapshot agent image build and bump OpenBao to v2.6.1.

- Pins the Alpine base image to the current latest version and digest
  - https://hub.docker.com/layers/library/alpine/3.24.1/images/sha256-79ff19e9084a00eece421b2523fb93e22d730e2c0e525905de047e848e56d95f
- Verifies the downloaded OpenBao release archive against the published SHA-256 checksums
- Uses `apk add --no-cache` when installing `s3cmd` to avoid using the APK package cache during installation
- Updates OpenBao from v2.5.0 to v2.6.1
- Add a `.dockerignore` to minimize docker build context

## Testing

Built the image successfully locally for `linux/arm64`.

```console
kangetsu@ubuntu24:~/oss/openbao-snapshot-agent$ docker build --no-cache -t snapshot-agent:test .
[+] Building 21.1s (8/8) FINISHED                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                        0.0s
 => => transferring dockerfile: 894B                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b                    0.0s
 => [internal] load .dockerignore                                                                                                                           0.0s
 => => transferring context: 85B                                                                                                                            0.0s
 => [internal] load build context                                                                                                                           0.0s
 => => transferring context: 78B                                                                                                                            0.0s
 => CACHED [1/3] FROM docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b                               0.1s
 => => resolve docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b                                      0.0s
 => [2/3] COPY kubernetes/bao-snapshot.sh /                                                                                                                 0.0s
 => [3/3] RUN if [[ "arm64" == "amd64" ]]; then         TARGETARCH="x86_64";     fi &&     wget "https://github.com/openbao/openbao/releases/download/v2.  11.6s
 => exporting to image                                                                                                                                      9.1s 
 => => exporting layers                                                                                                                                     7.3s 
 => => exporting manifest sha256:56bf1f0906a32000c39bd512e53ae05c6614294807de179033ea8661a174de6f                                                           0.0s 
 => => exporting config sha256:df903999a1ccea18ba5e7e6c573b053728488f8cda6b5f56e8bf679d74cda243                                                             0.0s 
 => => exporting attestation manifest sha256:de3d8db845b7a3b1f1e3db1f8c5bab3ac63e5d4a5bdfab3ce7ff5680fc19baf1                                               0.0s 
 => => exporting manifest list sha256:a356cf27b8e87fa2d17c23cd94860820403819530fe374c7e6f0f731cb84f11f                                                      0.0s
 => => naming to docker.io/library/snapshot-agent:test                                                                                                      0.0s
 => => unpacking to docker.io/library/snapshot-agent:test                                                                                                   1.7s
kangetsu@ubuntu24:~/oss/openbao-snapshot-agent$ 
```